### PR TITLE
Multiple satellites

### DIFF
--- a/Arduino_Wireless_Datalogger_DHT11/Arduino_Wireless_Datalogger_DHT11.ino
+++ b/Arduino_Wireless_Datalogger_DHT11/Arduino_Wireless_Datalogger_DHT11.ino
@@ -1,3 +1,7 @@
+#include <dht.h>
+
+
+
 //// TO DO
 //// Work on a low-power mode such that radio is only active when necessary
 //// Work on implementing controls signal communication so that base station can drive outputs on the satellite
@@ -16,13 +20,18 @@
 #include "Transmission.h"
 #include "BME280.h"
 
+//DHT STUFF FOR SHITTY TEST RIGS
+#define DHT11_PIN 2
+
+dht DHT;
+
 
 //
 // Hardware configuration
 //
 
-const float TEMPHYS = 0.5;  // Hysteresis values
-const float HUMHYS = 0.5; 
+const float TEMPHYS = 1.5;  // Hysteresis values
+const float HUMHYS = 1.5; 
 bool tempDelivered = false; //Only used for satellites.  Declared here for persistence over different loop() iterations
 bool humDelivered = false;  // Move these to one of the infinite internal loops at a later date
 
@@ -174,14 +183,13 @@ void loop(void) {
     while (role == role_satellite) {
 
       // Read the temp and humidity, and send two packets of type double whenever the change is sufficient.
-      readData();
+      //readData();
 
-      delay(5000);
-
-      temp_cal = calibration_T(temp_raw); //Get raw values from BME280
-      hum_cal = calibration_H(hum_raw);
-      temp_act = (double) temp_cal / 100.0; //Convert raw values to actual.  use round(value*10)/10(.0?) to get 1dp
-      hum_act = (double) hum_cal / 1024.0;
+      int chk = DHT.read11(DHT11_PIN);
+      if (chk == DHTLIB_OK) {
+        temp_act = double(DHT.temperature) - 1; //Quick and dirty calibration values
+        hum_act = double(DHT.humidity) + 5;
+      }
 
       printf("Just read temp=%i.%i, hum=%i.%i\n", int(temp_act), int(temp_act * 10) % 10, int(hum_act),
              int(hum_act * 10) % 10);

--- a/Arduino_Wireless_Datalogger_bleedingedge/Arduino_Wireless_Datalogger_bleedingedge.ino
+++ b/Arduino_Wireless_Datalogger_bleedingedge/Arduino_Wireless_Datalogger_bleedingedge.ino
@@ -21,7 +21,7 @@
 
 const unsigned int SATELLITES = 2;
 bool liveDevices[SATELLITES] = {1,1};
-const long long unsigned int DEADMANPERIOD = 1000 * 60 * 60 * 24; // Check once per day
+const long long unsigned int DEADMANPERIOD = 5000;//1000 * 60 * 60 * 24; // Check once per day
 long long unsigned int lastDeadmanCheck = 0; // Holds last time device status was checked
 
 const float TEMPHYS = 0.5;  // Hysteresis values
@@ -202,7 +202,7 @@ void loop(void) {
       // Read the temp and humidity, and send two packets of type double whenever the change is sufficient.
       readData();
 
-      delay(5000);
+      delay(5000); //Not actually sure why this is here.  Test removal when commission.
 
       temp_cal = calibration_T(temp_raw); //Get raw values from BME280
       hum_cal = calibration_H(hum_raw);
@@ -256,8 +256,20 @@ void loop(void) {
   if (role == role_base) {
 
     if (millis() - lastDeadmanCheck > DEADMANPERIOD) {
+      printf("%lu: Checking for life (last checked at %lu)\n", (millis() / 1000)), (long long unsigned int)(lastDeadmanCheck / 1000); // Timestamp (seconds since base start)
+      
       checkForLife(liveDevices);
       lastDeadmanCheck = millis();
+
+      for (int i = 0; i <= SATELLITES; i++) {
+        printf("Device %i ", i);
+        if (liveDevices[i]) {
+          printf("Live\n");
+        }
+        else {
+          printf("Non-responsive\n");
+        }
+      }
     }
     
     Transmission received(-1, 0.0,0.0);

--- a/Arduino_Wireless_Datalogger_bleedingedge/Arduino_Wireless_Datalogger_bleedingedge.ino
+++ b/Arduino_Wireless_Datalogger_bleedingedge/Arduino_Wireless_Datalogger_bleedingedge.ino
@@ -1,9 +1,7 @@
 //// TO DO
-//// Work on a low-power mode such that radio is only active when necessary
 //// Work on implementing controls signal communication so that base station can drive outputs on the satellite
 //// Sanity check for erroneous values (temp/hum should not change more than 1-2deg at a time, and value in array should be limited to this range of change
 //// Remember to comment out debug for final deployment
-//// Why is it sending non-changed packets?  Investigate.
 
 
 #include <EEPROM.h>
@@ -21,10 +19,17 @@
 // Hardware configuration
 //
 
+const unsigned int SATELLITES = 2;
+bool liveDevices[SATELLITES] = {1,1};
+const long long unsigned int DEADMANPERIOD = 1000 * 60 * 60 * 24; // Check once per day
+long long unsigned int lastDeadmanCheck = 0; // Holds last time device status was checked
+
 const float TEMPHYS = 0.5;  // Hysteresis values
 const float HUMHYS = 0.5; 
+
 bool tempDelivered = false; //Only used for satellites.  Declared here for persistence over different loop() iterations
 bool humDelivered = false;  // Move these to one of the infinite internal loops at a later date
+
 
 // Set up nRF24L01 radio on SPI bus plus pins 9 & 10 
 RF24 radio(9, 10);
@@ -35,7 +40,7 @@ RF24 radio(9, 10);
 //
 
 // Radio pipe addresses for the 2 nodes to communicate.
-const uint64_t pipes[2] = {0xF0F0F0F0E1LL, 0xF0F0F0F0D2LL};
+const uint64_t pipes[6] = {0xF0F0F0F0D0LL, 0xF0F0F0F0D1LL, 0xF0F0F0F0D2LL, 0xF0F0F0F0D3LL, 0xF0F0F0F0D4LL, 0xF0F0F0F0D5LL};
 
 
 //
@@ -58,6 +63,27 @@ const char* role_friendly_name[] = {"invalid", "base", "satellite"};
 int deviceID = -1;
 role_e role = role_base;
 
+bool deadmanCheck(int deviceID) {
+  bool deviceResponded = false;
+  long long unsigned int startTime = millis();
+
+  radio.stopListening();
+  radio.openWritingPipe(pipes[deviceID]);
+  
+  while (!deviceResponded && millis() - startTime < 1000) { //Try for 1000ms
+    deviceResponded = radio.write(&deviceResponded,sizeof(deviceResponded)); //Send a ping and wait for it to be read by target radio
+  }
+  
+  liveDevices[deviceID] = deviceResponded; //Write status to array
+  radio.startListening();
+}
+
+void checkForLife(bool checkedIn[]) {
+  for (int i = 1; i <= SATELLITES; i++) {
+    deadmanCheck(i);
+  }
+  lastDeadmanCheck = millis();
+}
 
 void setup(void) {
   ////Load settings from EEPROM and assign role
@@ -123,12 +149,12 @@ void setup(void) {
   // Open the 'other' pipe for reading, in position #1 (we can have up to 5 pipes open for reading)
 
   if (role == role_base) {
-    radio.openWritingPipe(pipes[0]);
-    radio.openReadingPipe(1, pipes[1]);
+    //radio.openWritingPipe(pipes[0]);
+    radio.openReadingPipe(1, pipes[0]); //Changed to 0 from 1, since 1-5 are for base-to-sat transmits
   }
   else {
-    radio.openWritingPipe(pipes[1]);
-    radio.openReadingPipe(1, pipes[0]);
+    radio.openWritingPipe(pipes[0]); //Changed from 1 to match above
+    radio.openReadingPipe(1, pipes[deviceID]); //Changed from 0 to give per-device private recieve channel
   }
 
   //
@@ -228,6 +254,11 @@ void loop(void) {
   //
 
   if (role == role_base) {
+
+    if (millis() - lastDeadmanCheck > DEADMANPERIOD) {
+      checkForLife(liveDevices);
+      lastDeadmanCheck = millis();
+    }
     
     Transmission received(-1, 0.0,0.0);
 

--- a/Arduino_Wireless_Datalogger_bleedingedge/Arduino_Wireless_Datalogger_bleedingedge.ino
+++ b/Arduino_Wireless_Datalogger_bleedingedge/Arduino_Wireless_Datalogger_bleedingedge.ino
@@ -105,6 +105,10 @@ void setup(void) {
   // improve reliability
   radio.setPayloadSize(8);
 
+  // Set the PA Level low to prevent power supply related issues since this is a
+  // getting_started sketch, and the likelihood of close proximity of the devices. RF24_PA_MAX is default.
+  radio.setPALevel(RF24_PA_LOW);
+
   //
   // Open pipes to other nodes for communication
   //

--- a/libraries/PuLogger/Transmission.h
+++ b/libraries/PuLogger/Transmission.h
@@ -2,9 +2,10 @@
 #define TRANSMISSION
 
 struct Transmission {
+  int xmitterID = -1;
   int tempRaw = 0;
   int humRaw = 0;
-  Transmission(double temp, double hum) : tempRaw(int(temp * 100)), humRaw(int(hum * 100)) {
+  Transmission(int xmitterID, double temp, double hum) : xmitterID(xmitterID), tempRaw(int(temp * 100)), humRaw(int(hum * 100)) {
     
   }
   float getTemp() { return float(tempRaw) / 100.0;}


### PR DESCRIPTION
Need to fix the deadman timer by eliminating delay() functions and running the main satellite loop on a period-based conditional.

Currently only recognises life if satellite has recently transmitted of its own accord.